### PR TITLE
[GH-27] Default workspace access token in now randomised

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,7 @@ const nextConfig = {
 		APP_SECRET_KEY: process.env.APP_SECRET_KEY,
 		APP_USERNAME: process.env.APP_USERNAME,
 		APP_PASSWORD: process.env.APP_PASSWORD,
+		DEFAULT_ACCESS_TOKEN: process.env.DEFAULT_ACCESS_TOKEN
 	},
 }
 

--- a/src/app/guide/components/Main/Main.tsx
+++ b/src/app/guide/components/Main/Main.tsx
@@ -14,7 +14,7 @@ type TMainProps = {
 }
 
 export const Main = (props: TMainProps) => {
-	const workspaces = [{ id: 0, name: "Default", accessToken: "032e6cde-c4a539f8-57e4aea1-95ea67f1" }, ...props.workspaces]
+	const workspaces = props.workspaces
 	const [selectedWorkspace, setSelectedWorkspace] = useState<Workspace>(workspaces[0])
 	const [shardConfig, setShardConfig] = useState<string>("")
 
@@ -26,7 +26,7 @@ export const Main = (props: TMainProps) => {
 		config.push(`accessToken = "${selectedWorkspace.accessToken}"`)
 		config.push(`endpoint = "${baseUrl}/api"`)
 		if (selectedWorkspace.id !== 0) {
-			config.push(`workspaceId = "${selectedWorkspace.id}"`)
+			config.push(`workspaceId = ${selectedWorkspace.id}`)
 		}
 
 		let configString = "tower {\n"

--- a/src/app/guide/page.tsx
+++ b/src/app/guide/page.tsx
@@ -1,6 +1,7 @@
 import { Main } from "./components"
 import { Workspace } from "@prisma/client"
 import { getAllWorkspaces } from "@/services/prisma"
+import { defaultTokenSecret } from "@/lib/secrets"
 
 export default async function Page() {
 	const props = await getData()
@@ -17,7 +18,7 @@ const getData = async () => {
 	}
 
 	return {
-		workspaces: workspaces,
+		workspaces: [{ id: 0, name: "Default", accessToken: defaultTokenSecret || 'Token is not set. The default workspace is locked!' }, ...workspaces],
 	}
 }
 

--- a/src/lib/secrets.ts
+++ b/src/lib/secrets.ts
@@ -1,6 +1,7 @@
 import { SignJWT, jwtVerify, JWTPayload } from "jose"
+import { logger } from "./logger"
 
-const defaultTokenSecret = "032e6cde-c4a539f8-57e4aea1-95ea67f1"
+export const defaultTokenSecret = process.env.DEFAULT_ACCESS_TOKEN
 const appSecretKey = new TextEncoder().encode(process.env.APP_SECRET_KEY)
 const appSecretAlgorithm = "HS256"
 const userName = process.env.APP_USERNAME || "nf-shard"
@@ -9,8 +10,12 @@ const userPassword = process.env.APP_PASSWORD || "nf-shard"
 
 export async function verifyAPIToken(base64APIToken: string, address: string, workspaceId: string | null) {
 
+	if (!defaultTokenSecret) {
+		logger.warn('The default access token is not defined in the environment. Rejecting token verification!')
+		return null
+	}
+	
 	if (!workspaceId) {
-		
 		return verifyAPITokenAgainstTarget(base64APIToken, defaultTokenSecret)
 	}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

## What's new?
- GH-27
- The token must be injected via `DEFAULT_ACCESS_TOKEN` environment variable
- A suitable token can be generated via: `openssl rand -hex 32 | sed -E 's/(.{16})(.{16})(.{16})(.{16})/\1-\2-\3-\4/'`